### PR TITLE
Personal filter suggestions

### DIFF
--- a/uBlock/assets.dev.json
+++ b/uBlock/assets.dev.json
@@ -897,6 +897,14 @@
         "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/block_third_party_fonts.txt",
         "supportURL": "https://github.com/yokoffing/filterlists/issues"
     },
+    "antitypo": {
+        "content": "filters",
+        "group": "annoyances malware",
+        "off": true,
+        "title": "iam-py-test's antitypo list",
+        "contentURL": "https://raw.githubusercontent.com/iam-py-test/my_filters_001/refs/heads/main/antitypo.txt",
+        "supportURL": "https://github.com/iam-py-test/my_filters_001/issues"
+    },
     "badblockclick": {
         "content": "filters",
         "group": "privacy",
@@ -1157,6 +1165,14 @@
         "contentURL": "https://gitlab.com/StevenBlack/hosts/-/raw/master/hosts",
         "supportURL": "https://github.com/StevenBlack/hosts/issues"
     },
+    "stevenblack fn+g": {
+        "content": "filters",
+        "group": "annoyances social",
+        "off": true,
+        "title": "Steven Black (fakenews + gambling)",
+        "contentURL": "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-only/hosts",
+        "supportURL": "https://github.com/StevenBlack/hosts/issues"
+    },
     "threatintel": {
         "content": "filters",
         "group": "malware",
@@ -1187,6 +1203,14 @@
         "title": "🔮 HaGeZi - Most Abused TLDs",
         "contentURL": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/adblock/spam-tlds-ublock.txt",
         "supportURL": "https://github.com/hagezi/dns-blocklists/issues"
+    },
+    "malicious-websites": {
+        "content": "filters",
+        "group": "malware",
+        "off": true,
+        "title": "The malicious website blocklist"
+        "contentURL": "https://raw.githubusercontent.com/iam-py-test/my_filters_001/refs/heads/main/antimalware.txt",
+        "supportURL": "https://github.com/iam-py-test/my_filters_001/issues"
     },
     "unsafe": {
         "content": "filters",
@@ -1244,7 +1268,7 @@
     },
     "ytneuter": {
         "content": "filters",
-        "group": "annoyances",
+        "group": "social",
         "off": true,
         "title": "YouTube Neuter",
         "contentURL": "https://raw.githubusercontent.com/mchangrh/yt-neuter/main/yt-neuter.txt",
@@ -1252,7 +1276,7 @@
     },
     "ytneutersb": {
         "content": "filters",
-        "group": "annoyances",
+        "group": "social",
         "off": true,
         "title": "YouTube Neuter - SponsorBlock Supplement",
         "contentURL": "https://raw.githubusercontent.com/mchangrh/yt-neuter/main/filters/sponsorblock.txt",

--- a/uBlock/assets.dev.json
+++ b/uBlock/assets.dev.json
@@ -958,12 +958,12 @@
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/abp/personal.txt",
         "supportURL": "https://badblock.celenity.dev/issues"
     },
-    "click2load": {
+    "clearurlsubo": {
         "content": "filters",
         "group": "privacy",
-        "title": "⛔ yokoffing's click2load filters",
-        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/click2load.txt",
-        "supportURL": "https://github.com/yokoffing/filterlists/issues"
+        "title": "ClearURLs for uBo (unofficial)",
+        "contentURL": "https://gitlab.com/DandelionSprout/adfilt/-/raw/master/ClearURLs%20for%20uBo/clear_urls_uboified.txt?ref_type=heads",
+        "supportURL": "https://github.com/DandelionSprout/adfilt/discussions/163"
     },
     "divested": {
         "content": "filters",
@@ -1119,6 +1119,13 @@
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/hardened/block-page-visibility.txt",
         "supportURL": "https://badblock.celenity.dev/issues"
     },
+    "privacyessentials": {
+        "content": "filters",
+        "group": "privacy",
+        "title": "🔒 Privacy Essentials",
+        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/privacy_essentials.txt",
+        "supportURL": "https://github.com/yokoffing/filterlists/issues"
+    },
     "quick-fixes": {
         "content": "filters",
         "group": "default",
@@ -1226,6 +1233,14 @@
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/hardened/unbreak-webrtc.txt",
         "supportURL": "https://badblock.celenity.dev/issues",
         "instructionURL": "https://codeberg.org/celenity/BadBlock/src/branch/pages/hardened"
+    },
+    "yal": {
+        "content": "filters",
+        "group": "annoyances",
+	"off": true,
+        "title": "🛠️ yokoffing's Annoyance List",
+        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/annoyance_list.txt",
+        "supportURL": "https://github.com/yokoffing/filterlists/issues"
     },
     "ytneuter": {
         "content": "filters",

--- a/uBlock/assets.main.json
+++ b/uBlock/assets.main.json
@@ -958,12 +958,12 @@
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/abp/personal.txt",
         "supportURL": "https://badblock.celenity.dev/issues"
     },
-    "click2load": {
+    "clearurlsubo": {
         "content": "filters",
         "group": "privacy",
-        "title": "⛔ yokoffing's click2load filters",
-        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/click2load.txt",
-        "supportURL": "https://github.com/yokoffing/filterlists/issues"
+        "title": "ClearURLs for uBo (unofficial)",
+        "contentURL": "https://gitlab.com/DandelionSprout/adfilt/-/raw/master/ClearURLs%20for%20uBo/clear_urls_uboified.txt?ref_type=heads",
+        "supportURL": "https://github.com/DandelionSprout/adfilt/discussions/163"
     },
     "divested": {
         "content": "filters",
@@ -1118,6 +1118,13 @@
         "title": "👻 Block Page Visibility",
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/hardened/block-page-visibility.txt",
         "supportURL": "https://badblock.celenity.dev/issues"
+   },
+    "privacyessentials": {
+        "content": "filters",
+        "group": "privacy",
+        "title": "🔒 Privacy Essentials",
+        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/privacy_essentials.txt",
+        "supportURL": "https://github.com/yokoffing/filterlists/issues"
     },
     "quick-fixes": {
         "content": "filters",
@@ -1226,6 +1233,14 @@
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/hardened/unbreak-webrtc.txt",
         "supportURL": "https://badblock.celenity.dev/issues",
         "instructionURL": "https://codeberg.org/celenity/BadBlock/src/branch/pages/hardened"
+    },
+    "yal": {
+        "content": "filters",
+        "group": "annoyances",
+	"off": true,
+        "title": "🛠️ yokoffing's Annoyance List",
+        "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/annoyance_list.txt",
+        "supportURL": "https://github.com/yokoffing/filterlists/issues"
     },
     "ytneuter": {
         "content": "filters",

--- a/uBlock/assets.main.json
+++ b/uBlock/assets.main.json
@@ -897,6 +897,14 @@
         "contentURL": "https://raw.githubusercontent.com/yokoffing/filterlists/main/block_third_party_fonts.txt",
         "supportURL": "https://github.com/yokoffing/filterlists/issues"
     },
+    "antitypo": {
+        "content": "filters",
+        "group": "annoyances malware",
+        "off": true,
+        "title": "iam-py-test's antitypo list",
+        "contentURL": "https://raw.githubusercontent.com/iam-py-test/my_filters_001/refs/heads/main/antitypo.txt",
+        "supportURL": "https://github.com/iam-py-test/my_filters_001/issues"
+    },
     "badblockclick": {
         "content": "filters",
         "group": "privacy",
@@ -1118,7 +1126,7 @@
         "title": "👻 Block Page Visibility",
         "contentURL": "https://gitlab.com/celenityy/BadBlock/-/raw/pages/hardened/block-page-visibility.txt",
         "supportURL": "https://badblock.celenity.dev/issues"
-   },
+    },
     "privacyessentials": {
         "content": "filters",
         "group": "privacy",
@@ -1157,6 +1165,14 @@
         "contentURL": "https://gitlab.com/StevenBlack/hosts/-/raw/master/hosts",
         "supportURL": "https://github.com/StevenBlack/hosts/issues"
     },
+    "stevenblack fn+g": {
+        "content": "filters",
+        "group": "annoyances social",
+        "off": true,
+        "title": "Steven Black (fakenews + gambling)",
+        "contentURL": "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-only/hosts",
+        "supportURL": "https://github.com/StevenBlack/hosts/issues"
+    },
     "threatintel": {
         "content": "filters",
         "group": "malware",
@@ -1187,6 +1203,14 @@
         "title": "🔮 HaGeZi - Most Abused TLDs",
         "contentURL": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/adblock/spam-tlds-ublock.txt",
         "supportURL": "https://github.com/hagezi/dns-blocklists/issues"
+    },
+    "malicious-websites": {
+        "content": "filters",
+        "group": "malware",
+        "off": true,
+        "title": "The malicious website blocklist"
+        "contentURL": "https://raw.githubusercontent.com/iam-py-test/my_filters_001/refs/heads/main/antimalware.txt",
+        "supportURL": "https://github.com/iam-py-test/my_filters_001/issues"
     },
     "unsafe": {
         "content": "filters",
@@ -1244,7 +1268,7 @@
     },
     "ytneuter": {
         "content": "filters",
-        "group": "annoyances",
+        "group": "social",
         "off": true,
         "title": "YouTube Neuter",
         "contentURL": "https://raw.githubusercontent.com/mchangrh/yt-neuter/main/yt-neuter.txt",
@@ -1252,7 +1276,7 @@
     },
     "ytneutersb": {
         "content": "filters",
-        "group": "annoyances",
+        "group": "social",
         "off": true,
         "title": "YouTube Neuter - SponsorBlock Supplement",
         "contentURL": "https://raw.githubusercontent.com/mchangrh/yt-neuter/main/filters/sponsorblock.txt",


### PR DESCRIPTION
First let me start off by saying, that feel free to ignore any suggestions or comment I make. 

I would personally would suggest adding these filters to the included default included list with ironfox.
They are constantly updated and come from developers already included. Privacy essentials is a broader version of an already included filter. [click2load] which is included in privacy essentials.

Forgive me for possible ignorance but is there are there reasons for why these shouldn't be included by default.  [was just comparing my own desktop filter list to the one included here, and found these ones lacking]

Added Privacy Essentials replacing yokoffing's click2load filters [since its included]
Added yokoffing's Annoyance List
Added ClearURLs for uBo (unofficial) [same author as Actually Legitimate URL Shortener Tool]